### PR TITLE
Add new message types for MPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/FrontierList.msg"
   "msg/VehicleState.msg"
   "msg/VehicleStateArray.msg"
+  "msg/ConstrainedVehicleState.msg"
+  "msg/ConstrainedVehicleStateArray.msg"
+  "msg/BoundAdjustment.msg"
+  "msg/ConstraintStatus.msg"
   DEPENDENCIES std_msgs geometry_msgs
 )
 

--- a/msg/BoundAdjustment.msg
+++ b/msg/BoundAdjustment.msg
@@ -1,0 +1,6 @@
+# Bound adjustment message for runtime adaptation
+std_msgs/Header header
+float64 left_bound_adjustment   # Adjustment to left bound [m] (positive = tighter)
+float64 right_bound_adjustment  # Adjustment to right bound [m] (positive = tighter)
+float64 confidence_adjustment   # Adjustment to confidence [0.0-1.0]
+bool reset_to_default          # Reset all adjustments to default values

--- a/msg/ConstrainedVehicleState.msg
+++ b/msg/ConstrainedVehicleState.msg
@@ -1,0 +1,10 @@
+# Enhanced vehicle state with MPC constraints
+# Contains position, velocity, heading angle, and adaptive bounds for MPC
+
+float64 x           # Position x coordinate [m]
+float64 y           # Position y coordinate [m] 
+float64 theta       # Heading angle [rad]
+float64 v_ref       # Reference velocity [m/s]
+float64 left_bound  # Left lateral bound [m]
+float64 right_bound # Right lateral bound [m]
+float64 confidence  # Confidence/tightness parameter [0.0-1.0]

--- a/msg/ConstrainedVehicleStateArray.msg
+++ b/msg/ConstrainedVehicleStateArray.msg
@@ -1,0 +1,3 @@
+# Array of constrained vehicle states for MPC trajectory representation
+std_msgs/Header header
+ConstrainedVehicleState[] states

--- a/msg/ConstraintStatus.msg
+++ b/msg/ConstraintStatus.msg
@@ -1,0 +1,9 @@
+# Status message for constraint system
+std_msgs/Header header
+bool constraints_active         # Whether constraints are currently being enforced
+bool bounds_violated           # Whether any bounds are currently violated
+bool adapting                  # Whether bounds are currently being adapted
+float64 avg_left_margin        # Average left margin across trajectory [m]
+float64 avg_right_margin       # Average right margin across trajectory [m]
+float64 avg_confidence         # Average confidence across trajectory [0.0-1.0]
+string status_message          # Human-readable status description

--- a/msg/VehicleState.msg
+++ b/msg/VehicleState.msg
@@ -1,7 +1,8 @@
 # Custom message for vehicle state
-# Contains position, velocity, and steering angle
+# Contains position, velocity, heading angle, and steering angle
 
 float64 x       # Position x coordinate [m]
 float64 y       # Position y coordinate [m] 
-float64 delta   # Steering angle [rad]
 float64 v       # Velocity [m/s]
+float64 theta   # Heading angle [rad]
+float64 delta   # Steering angle [rad]


### PR DESCRIPTION
Introduce new message types for constrained vehicle states and adjustments to support model predictive control (MPC). Update the existing VehicleState message to include heading angle.